### PR TITLE
Add minimum size for SearchTextField

### DIFF
--- a/NUITizenGallery/NUITizenGallery.cs
+++ b/NUITizenGallery/NUITizenGallery.cs
@@ -62,6 +62,7 @@ namespace NUITizenGallery
                 PlaceholderText = "Search",
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.WrapContent,
+                MinimumSize = new Size2D(0, 40),
             };
         }
 


### PR DESCRIPTION
There is an issue where if the Text of TextField is empty,
the height will be 0 due to the influence of the HeightSpecification WrapContent.

Fixing this on the platform can cause compatibility issues.
So this takes a long time because it requires discussion and decision.

Setting a minimum height in the app is a simple way to avoid this issue.

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>