### PR TITLE
Add popped event on Navigator for Unparent and Dispose page when it popped.

### DIFF
--- a/NUITizenGallery/NUITizenGallery.cs
+++ b/NUITizenGallery/NUITizenGallery.cs
@@ -229,6 +229,18 @@ namespace NUITizenGallery
             window.KeyEvent += OnKeyEvent;
 
             navigator = window.GetDefaultNavigator();
+            navigator.Popped += (object obj, PoppedEventArgs ev) => {
+
+                if (ev.Page != null)
+                {
+                    Tizen.Log.Error("NUI", $"Navigator page({ev.Page}) is popped!");
+                    /* FIXME: This code needs temporary!!
+                     *        Page will have a property to automate Unparent()
+                     *        and Dispose() when it popped from navigator. */
+                     ev.Page.Unparent();
+                     ev.Page.Dispose();
+                }
+            };
         }
 
         void OnSearchBtnClicked(object sender, ClickedEventArgs e)


### PR DESCRIPTION
when the page is popped,
we can see the page is not disposed and even time passed gc seems not working.
this patch call dispose forcely when it popped in the popped event.

discussed with @jaehyun0cho ,
we decide to add some boolean property to automate the disposing page after popping,
but this patch is necessary for current TizenFX version.