### PR TITLE
Fix ScrollViewTest7 to show all text items in the ScrollableBase

### DIFF
--- a/NUITizenGallery/Examples/ScrollViewTest/ScrollViewTest7Page.xaml
+++ b/NUITizenGallery/Examples/ScrollViewTest/ScrollViewTest7Page.xaml
@@ -28,19 +28,17 @@
                       Text="Random vertical scroll"
                       Size2D="{Binding Source={x:Static Window.Instance}, Path=Size }"
                       HeightSpecification="100"/>
-			<View x:Name="lblView">
-				<ScrollableBase x:Name="Scroller"
-                                  ScrollingDirection="Vertical"
-                                  HideScrollbar="false"
-                                  WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
-                                  HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
+            <ScrollableBase x:Name="Scroller"
+                ScrollingDirection="Vertical"
+                HideScrollbar="false"
+                WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
+                HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
 
-					<ScrollableBase.Layout>
-						<LinearLayout LinearOrientation="Vertical" CellPadding="10, 10"/>
-					</ScrollableBase.Layout>
+                <ScrollableBase.Layout>
+                    <LinearLayout LinearOrientation="Vertical" CellPadding="10, 10"/>
+                </ScrollableBase.Layout>
 
-				</ScrollableBase>
-			</View>
+            </ScrollableBase>
 		</View>
 	</ContentPage.Content>
 </ContentPage>


### PR DESCRIPTION
Previously, HeightSpecification of ScrollableBase was MatchParent, but
HeightSpecification of ScrollableBase's parent was WrapContent.
So the height was not calculated correctly due to the circular dependency and
some text items in the ScrollableBase could not be displayed.

Now, ScrollableBase's parent has been removed because it is not necessary.
Consequently, all text items in the ScrollableBase is displayed correctly.