### PR TITLE
Remove the duplicated codes on TextLabel

### DIFF
--- a/NUITizenGallery/Examples/HelloWorld/HelloWorldPage.xaml
+++ b/NUITizenGallery/Examples/HelloWorld/HelloWorldPage.xaml
@@ -14,9 +14,6 @@
     <ContentPage.Content>
         <TextLabel x:Name="test1PageText"
                      Text="Hello NUI XAML !"
-                     PositionUsesPivotPoint="True"
-                     ParentOrigin="Center"
-                     PivotPoint="Center"
                      WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
                      HeightSpecification="{Static LayoutParamPolicies.MatchParent}"
                      HorizontalAlignment="Center"

--- a/NUITizenGallery/Examples/Test1/Test1Page.xaml
+++ b/NUITizenGallery/Examples/Test1/Test1Page.xaml
@@ -14,9 +14,6 @@
     <ContentPage.Content>
         <TextLabel x:Name="test1PageText"
                      Text="Hello NUI XAML !"
-                     PositionUsesPivotPoint="True"
-                     ParentOrigin="Center"
-                     PivotPoint="Center"
                      WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
                      HeightSpecification="{Static LayoutParamPolicies.MatchParent}"
                      HorizontalAlignment="Center"


### PR DESCRIPTION
- In HelloWorldPage and Test1Page samples,
 TextLabel, which is a content of ContentPage, sets its Alignment as "Center".
- However, `PivotPoint` and `ParentOrigin` are also set as "Center" to TextLabel.
 Basically, View needs not to use `PivotPoint` and `ParentOrigin` on NUI Layout system.

- Also, when Accessibility is on and TextLabel gets focused, then its position
 is located incorrectly because of `PivotPoint` and `ParentOrigin`.
- So, removed the duplicated codes on TextLabel.

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>