### PR TITLE
Add RadioButtonGroup in SetColorTest.

### DIFF
--- a/NUITizenGallery/Examples/SetColorTest/SetColorTestPage.xaml.cs
+++ b/NUITizenGallery/Examples/SetColorTest/SetColorTestPage.xaml.cs
@@ -33,8 +33,13 @@ namespace NUITizenGallery
             ButtonColorName.Text = GetColorValues(ChangeColorButton.BackgroundColor);
             CheckBoxColorName.Text = GetColorValues(CheckBox2.BackgroundColor);
             ProgressBarColorName.Text = GetColorValues(ProgressBar.BackgroundColor);
+            RadioColorName.Text = GetColorValues(RadioButton2.BackgroundColor);
 
             ChangeColorButton.Clicked += OnChangeColorClicked;
+
+            RadioButtonGroup group = new RadioButtonGroup();
+            group.Add(RadioButton1);
+            group.Add(RadioButton2);
         }
 
         private Color GenerateColor(View component, TextLabel label)


### PR DESCRIPTION
Issue:
1. RadioButton1 and RadioButton2 can be selected simultaneously.
2. RadioColorName not shown. 

Solution:
Add RadioButtonGroup and assign RadioColorName to complete the functionality.