### PR TITLE
Fix issue of WebViewTest2 could not be shown in main page.

### DIFF
--- a/NUITizenGallery/NUITizenGallery.cs
+++ b/NUITizenGallery/NUITizenGallery.cs
@@ -150,6 +150,8 @@ namespace NUITizenGallery
     class Program : NUIApplication
     {
         private Window window;
+        private AppBar appBar;
+        private View pageContent;
         private Navigator navigator;
         private CollectionView colView;
         private ItemSelectionMode selMode;
@@ -221,6 +223,7 @@ namespace NUITizenGallery
             base.OnCreate();
             Initialize();
             SetMainPage();
+            pageContent.SizeHeight = Window.Instance.WindowSize.Height - appBar.SizeHeight;
         }
         private void Initialize()
         {
@@ -247,7 +250,7 @@ namespace NUITizenGallery
 
         private void SetMainPage()
         {
-            var appBar = new AppBar()
+            appBar = new AppBar()
             {
                 Title = "NUI Tizen Gallery",
                 AutoNavigationContent = false,
@@ -259,7 +262,7 @@ namespace NUITizenGallery
             appBar.NavigationContent = moreButton;
 
 
-            var pageContent = new View()
+            pageContent = new View()
             {
                 Layout = new LinearLayout()
                 {
@@ -299,6 +302,7 @@ namespace NUITizenGallery
                 }),
                 Header = myTitle,
                 ScrollingDirection = ScrollableBase.Direction.Vertical,
+                HideScrollbar = false,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 SelectionMode = selMode,


### PR DESCRIPTION
Issue:
The last item WebViewTest2 could not shown in main list view.

Because ContentPageLayout inherits from AbsoluteLayout, so set the ContentPage height to MatchParent is not appropriate at this point, we need consider the height of AppBar and specify the height of ContentPage, otherwise ContentPage will be squeezed out by AppBar.