### PR TITLE
Fix imperfect displayed issues.

### DIFF
--- a/NUITizenGallery/Examples/LayoutAddRemoveTest/LayoutAddRemoveTest1Page.xaml
+++ b/NUITizenGallery/Examples/LayoutAddRemoveTest/LayoutAddRemoveTest1Page.xaml
@@ -7,13 +7,12 @@
   HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
 
     <ContentPage.AppBar>
-        <AppBar Title="LayoutAddRemoveTest1"/>
+        <AppBar x:Name="appBar" Title="LayoutAddRemoveTest1"/>
     </ContentPage.AppBar>
-
+    
     <ContentPage.Content>
         <ScrollableBase x:Name="rootView"
-          WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
-          HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
+          WidthSpecification="{Static LayoutParamPolicies.MatchParent}" >
 
             <View.Layout>
                 <LinearLayout LinearOrientation="Vertical" CellPadding="10,10"/>

--- a/NUITizenGallery/Examples/LayoutAddRemoveTest/LayoutAddRemoveTest1Page.xaml.cs
+++ b/NUITizenGallery/Examples/LayoutAddRemoveTest/LayoutAddRemoveTest1Page.xaml.cs
@@ -26,6 +26,8 @@ namespace NUITizenGallery
         public LayoutAddRemoveTest1Page()
         {
             InitializeComponent();
+            rootView.SizeHeight = Window.Instance.WindowSize.Height - appBar.SizeHeight;
+
             addButton.Clicked += OnAddButtonClicked;
             removeButton.Clicked += OnRemoveButtonClicked;
         }

--- a/NUITizenGallery/Examples/NavigatorTest/NavigatorTest1Page.xaml
+++ b/NUITizenGallery/Examples/NavigatorTest/NavigatorTest1Page.xaml
@@ -13,8 +13,7 @@
     <!-- Content is main placeholder of ContentPage. Add your content into this view. -->
     <ContentPage.Content>
         <View x:Name="ContentView"
-          WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
-          HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
+          WidthSpecification="{Static LayoutParamPolicies.MatchParent}">
 
             <View.Layout>
                 <LinearLayout LinearOrientation="Vertical" CellPadding="0, 10"/>

--- a/NUITizenGallery/Examples/NavigatorTest/NavigatorTest1Page.xaml.cs
+++ b/NUITizenGallery/Examples/NavigatorTest/NavigatorTest1Page.xaml.cs
@@ -24,6 +24,7 @@ namespace NUITizenGallery
         public NavigatorTest1Page()
         {
             InitializeComponent();
+            ContentView.SizeHeight = Window.Instance.WindowSize.Height - appBar.SizeHeight;
         }
 
         private void SetButtonColor(NavigatorTest1Page page, int type)

--- a/NUITizenGallery/Examples/NavigatorTest/NavigatorTest2Page.xaml
+++ b/NUITizenGallery/Examples/NavigatorTest/NavigatorTest2Page.xaml
@@ -13,8 +13,7 @@
     <!-- Content is main placeholder of ContentPage. Add your content into this view. -->
     <ContentPage.Content>
         <View x:Name="ContentView"
-          WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
-          HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
+          WidthSpecification="{Static LayoutParamPolicies.MatchParent}">
 
             <View.Layout>
                 <LinearLayout LinearOrientation="Vertical" CellPadding="0, 10"/>

--- a/NUITizenGallery/Examples/NavigatorTest/NavigatorTest2Page.xaml.cs
+++ b/NUITizenGallery/Examples/NavigatorTest/NavigatorTest2Page.xaml.cs
@@ -24,6 +24,7 @@ namespace NUITizenGallery
         public NavigatorTest2Page()
         {
             InitializeComponent();
+            ContentView.SizeHeight = Window.Instance.WindowSize.Height - appBar.SizeHeight;
         }
 
         private void SetButtonColor(NavigatorTest2Page page, int type)

--- a/NUITizenGallery/Examples/RotationTest/RotationTest1Page.xaml
+++ b/NUITizenGallery/Examples/RotationTest/RotationTest1Page.xaml
@@ -13,24 +13,24 @@
     <!-- Content is main placeholder of ContentPage. Add your content into this view. -->
     <ContentPage.Content>
         <View x:Name="ContentView"
-          WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
-          HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
+          WidthSpecification="{Static LayoutParamPolicies.MatchParent}">
 
             <View.Layout>
                 <LinearLayout LinearOrientation="Vertical" LinearAlignment="Center" CellPadding="10, 10"/>
             </View.Layout>
 
             <Button x:Name="btn"
-                      Size2D="600, 100"
+                      Size2D="600, 90"
                       Text="WOW!!"
                       CellHorizontalAlignment="Center"
                       CellVerticalAlignment="Center"/>
             <View x:Name="rect"
-                    Size2D="600, 100"
+                    Size2D="600, 90"
                     BackgroundColor="Blue"
                     CellHorizontalAlignment="Center"
                     CellVerticalAlignment="Center" />
             <ImageView x:Name="img"
+                         SizeHeight="300"
                          CellHorizontalAlignment="Center"
                          CellVerticalAlignment="Center"/>
             <TextLabel x:Name="label"
@@ -39,7 +39,7 @@
                          CellVerticalAlignment="Center"/>
             <TextLabel Text="X:"/>
             <Slider x:Name="sliderX"
-                      Size2D="600, 50"
+                      Size2D="600, 40"
                       MinValue="0"
                       MaxValue="180"
                       BgTrackColor="#b1b1b1"
@@ -47,7 +47,7 @@
                       TrackThickness="5" />
             <TextLabel Text="Y:"/>
             <Slider x:Name="sliderY"
-                      Size2D="600, 50"
+                      Size2D="600, 40"
                       MinValue="0"
                       MaxValue="180"
                       BgTrackColor="#b1b1b1"
@@ -55,7 +55,7 @@
                       TrackThickness="5"/>
             <TextLabel Text="Z:"/>
             <Slider x:Name="sliderZ"
-                      Size2D="600, 50"
+                      Size2D="600, 40"
                       MinValue="0"
                       MaxValue="180"
                       BgTrackColor="#b1b1b1"

--- a/NUITizenGallery/Examples/RotationTest/RotationTest1Page.xaml.cs
+++ b/NUITizenGallery/Examples/RotationTest/RotationTest1Page.xaml.cs
@@ -27,6 +27,7 @@ namespace NUITizenGallery
         public RotationTest1Page()
         {
             InitializeComponent();
+            ContentView.SizeHeight = Window.Instance.WindowSize.Height - appBar.SizeHeight;
             img.SetImage(ResourcePath + "a.jpg");
 
             int count = 0;

--- a/NUITizenGallery/Examples/TabViewTest/TabViewTestPage.xaml
+++ b/NUITizenGallery/Examples/TabViewTest/TabViewTestPage.xaml
@@ -13,8 +13,7 @@
     <!-- Content is main placeholder of ContentPage. Add your content into this view. -->
     <ContentPage.Content>
         <TabView x:Name="tabView"
-                   WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
-                   HeightSpecification="{Static LayoutParamPolicies.MatchParent}" >
+                   WidthSpecification="{Static LayoutParamPolicies.MatchParent}">
         </TabView>
     </ContentPage.Content>
 

--- a/NUITizenGallery/Examples/TabViewTest/TabViewTestPage.xaml.cs
+++ b/NUITizenGallery/Examples/TabViewTest/TabViewTestPage.xaml.cs
@@ -28,6 +28,8 @@ namespace NUITizenGallery
         {
             InitializeComponent();
 
+            tabView.SizeHeight = Window.Instance.WindowSize.Height - appBar.SizeHeight;
+
             tabView.AddTab(CreateTabButton(), CreateView());
             tabCount++;
 

--- a/NUITizenGallery/Examples/VectorGraphicsTest/VectorGraphicsCanvasViewTest6Page.xaml.cs
+++ b/NUITizenGallery/Examples/VectorGraphicsTest/VectorGraphicsCanvasViewTest6Page.xaml.cs
@@ -42,7 +42,9 @@ namespace NUITizenGallery
             mDrawableGroup = new DrawableGroup();
             canvasView.AddDrawable(mDrawableGroup);
 
-            for(int i = 0; i < NumberOfPictures; i++)
+            contentView.SizeHeight = Window.Instance.WindowSize.Height - appBar.SizeHeight;
+
+            for (int i = 0; i < NumberOfPictures; i++)
             {
                 mPicture[i] = new Picture();
                 mPicture[i].Load(ResourcePath + Files[i]);

--- a/NUITizenGallery/Examples/VectorGraphicsTest/VectorGraphicsTVGTestPage.xaml
+++ b/NUITizenGallery/Examples/VectorGraphicsTest/VectorGraphicsTVGTestPage.xaml
@@ -19,7 +19,7 @@
           <View.Layout>
             <LinearLayout LinearOrientation="Vertical" CellPadding="10,10" LinearAlignment="Top"/>
           </View.Layout>
-          <ImageView x:Name="imageView" Size="{Binding Source={x:Static Window.Instance}, Path=Size }"/>
+            <ImageView x:Name="imageView" Size="{Binding Source={x:Reference ContentView}, Path=Size }"/>
 
         </View>
     </ContentPage.Content>

--- a/NUITizenGallery/Examples/WebViewTest/WebViewTest1Page.xaml.cs
+++ b/NUITizenGallery/Examples/WebViewTest/WebViewTest1Page.xaml.cs
@@ -34,6 +34,7 @@ namespace NUITizenGallery
         {
             InputField.GetInputMethodContext()?.HideInputPanel();
             TargetWebView.Url = InputField.Text;
+            TargetWebView.LoadUrl(TargetWebView.Url);
         }
 
         public void OnBackClicked(object sender, EventArgs e)


### PR DESCRIPTION
Because ContentPageLayout inherits from AbsoluteLayout, so set the ContentPage height to MatchParent is not appropriate at this point, we need consider the height of AppBar and specify the height of ContentPage, otherwise ContentPage will be squeezed out by AppBar.